### PR TITLE
feat: Implement CDN-first WASM loading for zero-config browser usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,19 +95,17 @@ const result = await hashImage(imageData);
 const hexHash: string = PDQ.toHex(result.hash);
 ```
 
-### Browser (with CDN)
+### Browser
 
-For browser environments, you can load the WASM module from a CDN:
+**The easiest way to use PDQ-WASM in the browser:**
 
 ```html
 <script type="module">
-  import { PDQ } from 'https://unpkg.com/pdq-wasm@0.3.2/dist/index.js';
+  import { PDQ } from 'https://unpkg.com/pdq-wasm@0.3.3/dist/esm/index.js';
 
   async function main() {
-    // Initialize with WASM URL from CDN
-    await PDQ.init({
-      wasmUrl: 'https://unpkg.com/pdq-wasm@0.3.2/wasm/pdq.wasm'
-    });
+    // Initialize - automatically loads WASM from CDN!
+    await PDQ.init();
 
     // Now use PDQ as normal
     const canvas = document.getElementById('myCanvas');
@@ -141,44 +139,109 @@ For browser environments, you can load the WASM module from a CDN:
 </script>
 ```
 
-**Available CDN URLs:**
-- **unpkg**: `https://unpkg.com/pdq-wasm@0.3.2/wasm/pdq.wasm`
-- **jsDelivr**: `https://cdn.jsdelivr.net/npm/pdq-wasm@0.3.2/wasm/pdq.wasm`
-- **GitHub Releases**: `https://github.com/Raudbjorn/pdq-wasm/releases/download/v0.3.0/pdq.wasm` (after uploading WASM as release asset)
+**Key Points:**
+- 🎉 **Zero configuration required!** Just call `PDQ.init()` and it automatically loads WASM from CDN
+- 📦 **No bundler setup needed** for quick prototyping
+- 🌐 **Production ready** with unpkg.com CDN (see self-hosting below for maximum control)
 
-For production use with a custom domain, you can:
-1. Set up GitHub Pages to serve the WASM files
-2. Configure a CNAME for your domain
-3. Load from your custom domain: `https://cdn.yourdomain.com/pdq.wasm`
+#### Using with npm + bundlers
 
-### Browser (ES Modules - Local Development)
-
-For local development or bundled applications, you can use ES modules directly:
-
-```html
-<script type="module">
-  import { PDQ } from './node_modules/pdq-wasm/dist/esm/index.js';
-
-  // Initialize with relative WASM URL
-  await PDQ.init({
-    wasmUrl: './node_modules/pdq-wasm/wasm/pdq.wasm'
-  });
-
-  // Use PDQ normally
-  const result = PDQ.hash(imageData);
-</script>
-```
-
-**With bundlers (Vite, Webpack, Rollup):**
+If you've installed via npm, you can use it in your bundled application:
 
 ```javascript
 import { PDQ } from 'pdq-wasm';
 
-// The bundler will automatically resolve the ES module
+// Option 1: Use CDN (easiest, zero config)
+await PDQ.init();
+
+// Option 2: Self-host for production (recommended)
 await PDQ.init({
-  wasmUrl: '/wasm/pdq.wasm'  // Copy wasm file to public directory
+  wasmUrl: '/assets/pdq.wasm'
 });
 ```
+
+#### Self-hosting WASM files (Recommended for production)
+
+While the CDN approach is convenient, for production we recommend self-hosting for better reliability and control:
+
+**Step 1: Copy WASM files to your static assets**
+```bash
+# Copy from node_modules after npm install
+cp node_modules/pdq-wasm/wasm/* public/assets/
+```
+
+**Step 2: Configure bundler (optional - automate the copy)**
+
+<details>
+<summary><strong>Vite Configuration</strong></summary>
+
+```bash
+npm install -D vite-plugin-static-copy
+```
+
+```javascript
+// vite.config.js
+import { defineConfig } from 'vite';
+import { viteStaticCopy } from 'vite-plugin-static-copy';
+
+export default defineConfig({
+  plugins: [
+    viteStaticCopy({
+      targets: [{
+        src: 'node_modules/pdq-wasm/wasm/*',
+        dest: 'assets'
+      }]
+    })
+  ]
+});
+```
+</details>
+
+<details>
+<summary><strong>Webpack Configuration</strong></summary>
+
+```bash
+npm install -D copy-webpack-plugin
+```
+
+```javascript
+// webpack.config.js
+const CopyPlugin = require('copy-webpack-plugin');
+
+module.exports = {
+  plugins: [
+    new CopyPlugin({
+      patterns: [{
+        from: 'node_modules/pdq-wasm/wasm',
+        to: 'assets'
+      }]
+    })
+  ]
+};
+```
+</details>
+
+**Step 3: Use your self-hosted files**
+```javascript
+await PDQ.init({ wasmUrl: '/assets/pdq.wasm' });
+```
+
+#### Available CDN Options
+
+If you prefer to use a CDN:
+
+- **unpkg** (default): `https://unpkg.com/pdq-wasm@0.3.3/wasm/pdq.wasm`
+- **jsDelivr**: `https://cdn.jsdelivr.net/npm/pdq-wasm@0.3.3/wasm/pdq.wasm`
+- **unpkg (latest)**: `https://unpkg.com/pdq-wasm@latest/wasm/pdq.wasm`
+
+You can also specify a custom CDN:
+```javascript
+await PDQ.init({
+  wasmUrl: 'https://your-cdn.com/pdq.wasm'
+});
+```
+
+#### Module System Support
 
 **Package exports both CommonJS and ES Modules:**
 - ES Module: `pdq-wasm/dist/esm/index.js` (for browsers and modern Node.js)

--- a/examples/browser/index.html
+++ b/examples/browser/index.html
@@ -136,25 +136,25 @@
     <p><strong>Similarity:</strong> Percentage similarity based on the Hamming distance (100% - (distance/256 * 100)).</p>
   </div>
 
-  <!-- Using unpkg.com CDN for demonstration -->
+  <!-- PDQ WASM - Zero Configuration Required! -->
   <script type="module">
-    // For production, you would typically bundle this with your build system
-    // This example uses a local build - adjust the path as needed
+    // This example demonstrates the CDN-first approach
+    // Option 1: Use CDN (recommended for getting started)
+    // import { PDQ } from 'https://unpkg.com/pdq-wasm@0.3.3/dist/esm/index.js';
 
-    // In a real deployment, you'd import from CDN or your bundled version:
-    // import { PDQ } from 'https://unpkg.com/pdq-wasm@latest/dist/index.mjs';
-
-    // For this example, we'll load from the local build
+    // Option 2: Use local build (for development)
     // You may need to serve this with a local server due to CORS restrictions
-    import { PDQ } from '../../dist/index.js';
+    import { PDQ } from '../../dist/esm/index.js';
 
     let hash1 = null;
     let hash2 = null;
 
-    // Initialize PDQ
+    // Initialize PDQ - Now with ZERO configuration!
+    // The library automatically loads WASM from CDN if not specified
     console.log('Initializing PDQ WASM module...');
-    await PDQ.init();
+    await PDQ.init(); // That's it! No wasmUrl needed for browsers
     console.log('PDQ WASM module initialized');
+    console.log('✓ WASM loaded automatically from CDN');
 
     const image1Input = document.getElementById('image1Input');
     const image2Input = document.getElementById('image2Input');
@@ -208,7 +208,7 @@
 
       const distance = PDQ.hammingDistance(hash1.hash, hash2.hash);
       const similarity = PDQ.similarity(hash1.hash, hash2.hash);
-      const isSimilar = PDQ.isSimilar(hash1.hash, hash2.hash); // Uses default threshold of 31
+      const isSimilar = PDQ.areSimilar(hash1.hash, hash2.hash); // Uses default threshold of 31
 
       comparisonResult.innerHTML = `
         <div class="comparison">

--- a/examples/nodejs/basic-usage.js
+++ b/examples/nodejs/basic-usage.js
@@ -67,7 +67,7 @@ async function main() {
   console.log('4. Comparing hashes...');
   const distance = PDQ.hammingDistance(result.hash, result2.hash);
   const similarity = PDQ.similarity(result.hash, result2.hash);
-  const isSimilar = PDQ.isSimilar(result.hash, result2.hash);
+  const isSimilar = PDQ.areSimilar(result.hash, result2.hash);
 
   console.log(`   Hamming distance: ${distance} / 256`);
   console.log(`   Similarity: ${similarity.toFixed(2)}%`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2415,7 +2414,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -3502,7 +3500,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -5365,7 +5362,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
This change significantly improves the developer experience by automatically loading WASM files from CDN when PDQ.init() is called in a browser without providing a wasmUrl option.

Changes:
- Updated PDQ.init() to default to unpkg CDN for browser environments
- Simplified browser usage to require zero configuration
- Updated README with comprehensive CDN-first documentation
- Added collapsible sections for Vite and Webpack configurations
- Fixed method name from PDQ.isSimilar to PDQ.areSimilar in examples
- Updated browser example to demonstrate zero-config initialization
- Maintained backward compatibility with custom wasmUrl option
- Node.js behavior unchanged (still uses bundled WASM files)

Benefits:
- No bundler configuration required for quick start
- No manual WASM file copying needed
- Works out-of-the-box with CDN (unpkg.com by default)
- Production-ready with self-hosting option clearly documented

Fixes #<issue-number> (npm install error for users trying to load WASM)

## Summary by Sourcery

Implement a CDN-first approach for loading WASM in the browser with zero configuration, while preserving custom wasmUrl support and existing Node.js behavior

New Features:
- Automatically load WASM from unpkg CDN when PDQ.init() is called in browser without a wasmUrl

Bug Fixes:
- Fix example method calls by renaming PDQ.isSimilar to PDQ.areSimilar

Enhancements:
- Add zero-configuration browser usage workflow and self-hosting examples with Vite and Webpack
- Maintain backward compatibility with custom wasmUrl option and unchanged Node.js bundled behavior

Documentation:
- Revamp README with simplified browser instructions, collapsible bundler configurations, and comprehensive CDN URL options